### PR TITLE
set the repository base directory for codecov script

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -406,7 +406,7 @@ for t in $(unify_list " ,;" "$TEST") ; do
          # Output coverage data for debugging
          travis_run "lcov --list coverage.info"
          # Upload to codecov.io: -f specifies file(s) to upload and disables manual coverage gathering
-         travis_run --title "Upload report" bash <(curl -s https://codecov.io/bash) -f coverage.info
+         travis_run --title "Upload report" bash <(curl -s https://codecov.io/bash) -f coverage.info -R $ROS_WS/src/$REPOSITORY_NAME
          travis_fold end codecov.io
          ;;
    esac


### PR DESCRIPTION
I was suspicious this might be the reason it wasn't working.  See the report I linked.  I'll close my other PR to moveit_ci now.